### PR TITLE
Fixes animation pause/play functionality

### DIFF
--- a/libs/design-system/src/lib/icons/Pause.tsx
+++ b/libs/design-system/src/lib/icons/Pause.tsx
@@ -5,9 +5,9 @@ export default () => (
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    stroke-width="1"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeWidth="1"
+    strokeLinecap="round"
+    strokeLinejoin="round"
     xmlns="http://www.w3.org/2000/svg"
   >
     <rect x="6" y="4" width="4" height="16" />

--- a/libs/design-system/src/lib/icons/Play.tsx
+++ b/libs/design-system/src/lib/icons/Play.tsx
@@ -5,9 +5,9 @@ export default () => (
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    stroke-width="1"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeWidth="1"
+    strokeLinecap="round"
+    strokeLinejoin="round"
     xmlns="http://www.w3.org/2000/svg"
   >
     <polygon points="6 4 20 12 6 20 6 4" />


### PR DESCRIPTION
- Previously the animation was being destroyed and re-created whenever it was paused via the toggle. This is not fixed by splitting the use-effect
- Also fixed incorrect usage of setSegments instead of goToAndStop
- Fixed React warnings about SVG properties being snake-case